### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/apps/guestbook/templates/guestbook/guestbook.html
+++ b/apps/guestbook/templates/guestbook/guestbook.html
@@ -447,9 +447,16 @@
                             const messageContainer = guestbookMessages.lastElementChild;
                             const messageParagraph = messageContainer.querySelector('p');
                             if (messageParagraph) {
-                                messageParagraph.textContent = data.message.message.replace(/\n/g, '\n');
-                                // Convert line breaks to HTML for display
-                                messageParagraph.innerHTML = messageParagraph.textContent.replace(/\n/g, '<br>');
+                                messageParagraph.textContent = data.message.message;
+                                // Convert line breaks to HTML for display safely
+                                const lines = messageParagraph.textContent.split('\n');
+                                messageParagraph.textContent = ''; // Clear existing content
+                                lines.forEach((line, index) => {
+                                    if (index > 0) {
+                                        messageParagraph.appendChild(document.createElement('br'));
+                                    }
+                                    messageParagraph.appendChild(document.createTextNode(line));
+                                });
                             }
                             
                             messageInput.value = "";


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/ridwaanhall-com/security/code-scanning/2](https://github.com/ridwaanhall/ridwaanhall-com/security/code-scanning/2)

To fix the issue, we need to ensure that the user input is properly sanitized and that no untrusted content is directly assigned to `innerHTML`. Instead of using `innerHTML`, we can create a safer alternative by splitting the text content on line breaks (`\n`) and appending text nodes and `<br>` elements programmatically. This approach avoids interpreting the input as HTML while preserving the intended formatting.

The changes will be made in the JavaScript section of the provided HTML file, specifically around line 452.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
