### PR TITLE
Upgrade dependencies: cffi, psycopg2-binary, and add markdown-it-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.8.1
 certifi==2025.1.31
-cffi==1.17.1
+cffi==2.0.0
 charset-normalizer==3.4.1
 cryptography==45.0.4
 Django==5.2.8
@@ -8,10 +8,11 @@ django-allauth==65.9.0
 django-csp==4.0
 django-permissions-policy==4.25.0
 idna==3.10
+markdown-it-py==4.0.0
 mdurl==0.1.2
 oauthlib==3.2.2
 packaging==25.0
-psycopg2-binary==2.9.10
+psycopg2-binary==2.9.11
 pycparser==2.22
 Pygments==2.19.1
 PyJWT==2.10.1


### PR DESCRIPTION
Upgrade cffi to version 2.0.0 and psycopg2-binary to version 2.9.11. Additionally, include markdown-it-py version 4.0.0 in the requirements.